### PR TITLE
Update stimulus-rails-autosave docs

### DIFF
--- a/_docs/stimulus-rails-autosave.md
+++ b/_docs/stimulus-rails-autosave.md
@@ -29,7 +29,7 @@ $ yarn add stimulus-rails-autosave
 
 And use it in your JS file:
 ```js
-import { Application } from "stimulus"
+import { Application } from "@hotwired/stimulus"
 import Autosave from "stimulus-rails-autosave"
 
 const application = Application.start()


### PR DESCRIPTION
To reflect the upgrade to Stimulus 3.0 on https://github.com/stimulus-components/stimulus-rails-autosave/pull/1