### PR TITLE
Fix typo "ressources" in rails routes

### DIFF
--- a/content/docs/stimulus-content-loader.md
+++ b/content/docs/stimulus-content-loader.md
@@ -48,7 +48,7 @@ In your routes:
 
 ```ruby
 Rails.application.routes.draw do
-ressources
+resources
   get :comments, to: 'posts#comments'
 end
 ```

--- a/content/docs/stimulus-popover.md
+++ b/content/docs/stimulus-popover.md
@@ -42,7 +42,7 @@ In your routes:
 
 ```ruby
 Rails.application.routes.draw do
-ressources
+resources
   get :card, to: 'users#card'
 end
 ```


### PR DESCRIPTION
Fix rails routes typo in docs for:
- stimulus-content-loader
- stimulus-popover