### PR TITLE
Removing HTML self-closing slash

### DIFF
--- a/content/docs/stimulus-password-visibility.md
+++ b/content/docs/stimulus-password-visibility.md
@@ -30,7 +30,7 @@ In your view:
 
 ```html
 <div data-controller="password-visibility">
-  <input type="password" data-password-visibility-target="input" spellcheck="false" />
+  <input type="password" data-password-visibility-target="input" spellcheck="false">
 
   <button type="button" data-action="password-visibility#toggle">
     <span data-password-visibility-target="icon">Eye</span>


### PR DESCRIPTION
https://validator.w3.org/nu/ says:

> Warning: Self-closing tag syntax in text/html documents is [widely discouraged](https://google.github.io/styleguide/htmlcssguide.html#Document_Type); it’s unnecessary and [interacts badly with other HTML features](https://software.hixie.ch/utilities/js/live-dom-viewer/?saved=10809) (e.g., unquoted attribute values). If you’re using a tool that injects self-closing tag syntax into all void elements, [without any option to prevent it from doing so](https://github.com/prettier/prettier/issues/5246), then consider switching to a different tool.