### PR TITLE
Fix error in usage for Stimulus Chartjs

### DIFF
--- a/content/docs/stimulus-chartjs.md
+++ b/content/docs/stimulus-chartjs.md
@@ -1,7 +1,7 @@
 ---
 title: Chartjs
 description: A Stimulus controller to deal with chart.js.
-package: chartjs
+package: chart
 packagePath: '@stimulus-components/chartjs'
 ---
 


### PR DESCRIPTION
The install block has you register the controller as `chartjs`. I was going nuts trying to figure out what I was doing wrong when it didn't work until I realized this. 

<img width="849" alt="image" src="https://github.com/stimulus-components/stimulus-components/assets/622516/916c029c-3843-4e57-93b5-84ee2ffeae36">
