### PR TITLE
Add max-height feature for textarea autogrow

### DIFF
--- a/components/textarea-autogrow/src/index.ts
+++ b/components/textarea-autogrow/src/index.ts
@@ -4,11 +4,16 @@ import { debounce } from "../../../utils"
 export default class extends Controller<HTMLInputElement> {
   declare onResize: EventListenerOrEventListenerObject // eslint-disable-line no-undef
   declare resizeDebounceDelayValue: number
+  declare maxHeightValue: number
 
   static values = {
     resizeDebounceDelay: {
       type: Number,
       default: 100,
+    },
+    maxHeight: {
+      type: Number,
+      default: 0,
     },
   }
 
@@ -34,6 +39,11 @@ export default class extends Controller<HTMLInputElement> {
 
   autogrow(): void {
     this.element.style.height = "auto" // Force re-print before calculating the scrollHeight value.
-    this.element.style.height = `${this.element.scrollHeight}px`
+    const [heightVal, overflowVal] =
+      this.maxHeightValue > 0 && this.element.scrollHeight >= this.maxHeightValue
+        ? [this.maxHeightValue, "scroll"] // Stop autogrow and enable scrolling
+        : [this.element.scrollHeight, "hidden"]
+    this.element.style.height = `${heightVal}px`
+    this.element.style.overflow = overflowVal
   }
 }


### PR DESCRIPTION
Redoing the PR from https://github.com/stimulus-components/stimulus-textarea-autogrow/pull/11

I added a feature of max height so the textarea doesn't grow past that. After max-height the overflow style switches to scroll and it switches back to hidden if you delete enough lines.

To use max-height you put the attribute 'data-textarea-autogrow-max-height-value' on the html textarea element.
