### PR TITLE
Fix Chartjs component for usage with importmaps

### DIFF
--- a/components/chartjs/src/index.ts
+++ b/components/chartjs/src/index.ts
@@ -1,5 +1,7 @@
 import { Controller } from "@hotwired/stimulus"
-import { Chart, ChartType, ChartOptions, ChartData } from "chart.js/auto"
+import { Chart, registerables, ChartType, ChartOptions, ChartData } from "chart.js"
+
+Chart.register(...registerables);
 
 export default class Chartjs extends Controller<HTMLCanvasElement> {
   declare canvasTarget: HTMLCanvasElement

--- a/components/chartjs/vite.config.mts
+++ b/components/chartjs/vite.config.mts
@@ -12,10 +12,10 @@ export default defineConfig({
       fileName: "stimulus-chartjs",
     },
     rollupOptions: {
-      external: ["chart.js/auto", "@hotwired/stimulus"],
+      external: ["chart.js", "@hotwired/stimulus"],
       output: {
         globals: {
-          "chart.js/auto": "Chart",
+          "chart.js": "Chart",
           "@hotwired/stimulus": "Stimulus",
         },
       },


### PR DESCRIPTION
The chart.js/auto package does not work with importmaps due to it being in a subfolder of the main package (see issue stimulus-components/stimulus-components#97).

Since the auto package is really simple and stimulus-components are mainly used in rails apps that now default to importmaps for javascript management, it seems to be sensible to integrate the auto package code in this stimulus controller to solve the issue.

An other option would have been to fix the issue in the chart.js repository but it seems more complicated because it's not very clear how they build the auto package.