### PR TITLE
Correct package name (chartjs)

### DIFF
--- a/docs/content/docs/stimulus-chartjs.md
+++ b/docs/content/docs/stimulus-chartjs.md
@@ -1,7 +1,7 @@
 ---
 title: Chartjs
 description: A Stimulus controller to deal with chart.js.
-package: chart
+package: chartjs
 packagePath: "@stimulus-components/chartjs"
 ---
 


### PR DESCRIPTION
This pull request includes a small but important change to the `docs/content/docs/stimulus-chartjs.md` file. The change corrects the package name to ensure clarity and accuracy in the documentation.

* [`docs/content/docs/stimulus-chartjs.md`](diffhunk://#diff-de6af1ebc39665959c9d4a34fd39f3944baa637bd75d08340993cf1c555524e2L4-R4): Changed the package name from `chart` to `chartjs` to accurately reflect the package being documented, and correct the github link.