### PR TITLE
Allow more flexible peer dependency (@rails/request.js)

### DIFF
--- a/components/sortable/package.json
+++ b/components/sortable/package.json
@@ -31,7 +31,7 @@
   },
   "peerDependencies": {
     "@hotwired/stimulus": "^3",
-    "@rails/request.js": "^0.0.8",
+    "@rails/request.js": "~0.0.8",
     "sortablejs": "^1.15.0"
   }
 }


### PR DESCRIPTION
Update @rails/request.js peer dependency to be more flexible with other packages.

If another package was using 0.0.9, this would conflict with 0.0.8 used here.