### PR TITLE
Add thousands separator to character counter

### DIFF
--- a/components/character-counter/src/index.ts
+++ b/components/character-counter/src/index.ts
@@ -22,7 +22,7 @@ export default class CharacterCounter extends Controller {
   }
 
   update(): void {
-    this.counterTarget.innerHTML = this.count.toString()
+    this.counterTarget.innerHTML = this.count.toLocaleString()
   }
 
   get count(): number {


### PR DESCRIPTION
"1000" is now "1,000" in a US locale