### PR TITLE
refactor: Adjust layout to improve usability and readability

### DIFF
--- a/docs/components/Docs/AltSidebar.vue
+++ b/docs/components/Docs/AltSidebar.vue
@@ -1,18 +1,16 @@
 <template>
-  <div class="hidden lg:block">
-    <nav class="whitespace-nowrap">
-      <h3 class="font-display text-sm font-medium text-slate-900 dark:text-white">Community</h3>
+  <nav class="whitespace-nowrap">
+    <h3 class="font-display text-sm font-medium text-slate-900 dark:text-white">Community</h3>
 
-      <ol role="list" class="mt-2 space-y-3 text-slate-500">
-        <li v-for="link in links" :key="link.title">
-          <a class="hover:text-orange-600 flex gap-2 items-center" :href="link.path" target="_blank">
-            <component :is="link.icon" class="size-5" />
-            {{ link.title }}
-          </a>
-        </li>
-      </ol>
-    </nav>
-  </div>
+    <ol role="list" class="mt-2 space-y-3 text-slate-500">
+      <li v-for="link in links" :key="link.title">
+        <a class="hover:text-orange-600 flex gap-2 items-center" :href="link.path" target="_blank">
+          <component :is="link.icon" class="size-5" />
+          {{ link.title }}
+        </a>
+      </li>
+    </ol>
+  </nav>
 </template>
 
 <script setup>

--- a/docs/components/Docs/Sidebar.vue
+++ b/docs/components/Docs/Sidebar.vue
@@ -1,6 +1,6 @@
 <template>
-  <nav>
-    <ul class="space-y-9 whitespace-nowrap">
+  <nav class="block md:sticky md:top-16">
+    <ul class="max-h-[calc(100dvh-64px)] md:overflow-y-scroll space-y-9 whitespace-nowrap md:px-6 md:pt-4 md:pb-8">
       <li v-for="section in sections" :key="section.title">
         <h2 class="dark:text-white font-display font-medium text-slate-900">
           {{ section.title }}

--- a/docs/components/content/InstallationBlock.vue
+++ b/docs/components/content/InstallationBlock.vue
@@ -7,7 +7,7 @@
       >
         <h3 class="text-sm font-semibold text-gray-800 dark:text-gray-200">Install the package</h3>
 
-        <div class="flex gap-6 mt-6 overflow-x-scroll">
+        <div class="flex gap-6 mt-6 overflow-x-auto">
           <button
             v-for="(tab, index) in tabs"
             :key="index"

--- a/docs/layouts/docs.vue
+++ b/docs/layouts/docs.vue
@@ -2,22 +2,21 @@
   <div class="flex flex-col min-h-screen dark:bg-slate-800">
     <Nav />
 
-    <main class="flex px-4 py-8">
-      <div class="flex-1 flex flex-col md:flex-row max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 overflow-x-scroll gap-4">
-        <div class="hidden md:block border-b md:border-b-0 pb-4 md:pr-4">
-          <DocsSidebar />
-        </div>
+    <main class="px-4 max-w-screen md:grid md:grid-cols-[230px_auto] xl:grid-cols-[260px_auto_200px] xl:gap-8">
+      <div class="hidden md:block">
+        <DocsSidebar />
+      </div>
 
-        <div
-          class="prose dark:prose-invert max-w-none overflow-x-scroll prose-pre:mt-0 prose-pre:rounded-t-none prose-pre:rounded-b-xl prose-table:whitespace-nowrap"
-        >
-          <slot />
-        </div>
+      <div
+        class="md:max-w-[500px] lg:max-w-[700px] xl:max-w-[864px] mx-auto prose dark:prose-invert prose-pre:mt-0 prose-pre:rounded-t-none prose-pre:rounded-b-xl prose-table:whitespace-nowrap"
+      >
+        <slot />
+        <Footer />
+      </div>
 
+      <div class="hidden xl:block fixed right-0 top-16 p-4">
         <DocsAltSidebar />
       </div>
     </main>
-
-    <Footer />
   </div>
 </template>


### PR DESCRIPTION
Hi, 

I tried to adjust the layout of the page a bit differently in order to allow the users to scroll the different components without losing context of the current position. I think the usability and readibility improve a bit like this.

I moved the sidebars to the sides of the page and left the main content in the center. I think it's easier to read the documentation with some extra spacing.

The  horizontal scrollbars  are also removed when they're not needed:
![image](https://github.com/user-attachments/assets/3d7d0786-641d-4c71-814a-9273486c1c61)

![image](https://github.com/user-attachments/assets/d3d55f90-2c71-4192-96a2-a5bff0d74f93)


Demo:
![demo-scroll](https://github.com/user-attachments/assets/958c2e06-ca02-419f-893a-b3a8403f5705)
