### PR TITLE
Improve Confirmation Component to Handle Dynamic Targets

### DIFF
--- a/components/confirmation/CHANGELOG.md
+++ b/components/confirmation/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.1] - 2025-02-28
+
+### Added
+
+- Used the existing Stimulus `inputTargetConnect` and `inputTargetDisconnect` callbacks to re-run `check()` when targets are added or removed from the DOM, improving support for dynamically updated forms.
+
+
 ## [1.0.0] - 2024-12-17
 
 ### Added

--- a/components/confirmation/CHANGELOG.md
+++ b/components/confirmation/CHANGELOG.md
@@ -13,7 +13,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Used the existing Stimulus `inputTargetConnect` and `inputTargetDisconnect` callbacks to re-run `check()` when targets are added or removed from the DOM, improving support for dynamically updated forms.
 
-
 ## [1.0.0] - 2024-12-17
 
 ### Added

--- a/components/confirmation/package.json
+++ b/components/confirmation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stimulus-components/confirmation",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A Stimulus controller to confirm actions manually",
   "keywords": [
     "stimulus",

--- a/components/confirmation/spec/index.test.ts
+++ b/components/confirmation/spec/index.test.ts
@@ -5,7 +5,7 @@
 import { beforeEach, describe, it, expect } from "vitest"
 import { Application } from "@hotwired/stimulus"
 import Confirmation from "../src/index"
-import { nextFrame } from "../../../utils"
+import { sleep } from "../../../utils"
 
 const startStimulus = (): void => {
   const application = Application.start()
@@ -144,7 +144,7 @@ describe("#check", () => {
       newInput.value = "DELETE"
 
       form.appendChild(newInput)
-      await nextFrame()
+      await sleep()
 
       const itemsEnabled = document.querySelectorAll<HTMLInputElement>("[data-confirmation-target='item']:enabled")
       expect(itemsEnabled.length).toBe(1)

--- a/components/confirmation/spec/index.test.ts
+++ b/components/confirmation/spec/index.test.ts
@@ -5,6 +5,7 @@
 import { beforeEach, describe, it, expect } from "vitest"
 import { Application } from "@hotwired/stimulus"
 import Confirmation from "../src/index"
+import { nextFrame } from "../../../utils"
 
 const startStimulus = (): void => {
   const application = Application.start()
@@ -106,6 +107,55 @@ describe("#check", () => {
 
       const itemsEnabled = document.querySelectorAll<HTMLInputElement>("[data-confirmation-target='item']:enabled")
       expect(itemsEnabled.length).toBe(0)
+    })
+  })
+
+  describe("dynamic input handling", () => {
+    beforeEach((): void => {
+      startStimulus()
+
+      document.body.innerHTML = `
+        <form data-controller="confirmation">
+          <input
+            id="confirmation"
+            data-confirmation-target="input"
+            data-confirmation-content="DELETE"
+            data-action="confirmation#check"
+          />
+
+          <button data-confirmation-target="item" disabled>Delete</button>
+        </form>
+      `
+    })
+    it("should re-run check when a new input is added", async () => {
+      const form = document.querySelector<HTMLFormElement>("[data-controller='confirmation']")
+      const input = document.querySelector<HTMLInputElement>("#confirmation")
+      const itemsDisabled = document.querySelectorAll<HTMLInputElement>("[data-confirmation-target='item']:disabled")
+
+      expect(itemsDisabled.length).toBe(1)
+
+      input.remove()
+
+      const newInput = document.createElement("input")
+      newInput.setAttribute("id", "confirmation")
+      newInput.setAttribute("data-confirmation-target", "input")
+      newInput.setAttribute("data-confirmation-content", "DELETE")
+      newInput.setAttribute("data-action", "confirmation#check")
+      newInput.value = "DELETE"
+
+      form.appendChild(newInput)
+      await nextFrame()
+
+      const itemsEnabled = document.querySelectorAll<HTMLInputElement>("[data-confirmation-target='item']:enabled")
+      expect(itemsEnabled.length).toBe(1)
+    })
+
+    it("should re-run check when an input is removed", () => {
+      const input = document.querySelector<HTMLInputElement>("#confirmation")
+      input.remove()
+
+      const itemsEnabledAfter = document.querySelectorAll<HTMLInputElement>("[data-confirmation-target='item']:enabled")
+      expect(itemsEnabledAfter.length).toBe(0)
     })
   })
 })

--- a/components/confirmation/src/index.ts
+++ b/components/confirmation/src/index.ts
@@ -20,7 +20,7 @@ export default class Confirmation extends Controller<HTMLFormElement> {
     })
   }
 
-  inputTargetConnect(): void {
+  inputTargetConnected(): void {
     this.check()
   }
 

--- a/components/confirmation/src/index.ts
+++ b/components/confirmation/src/index.ts
@@ -24,7 +24,7 @@ export default class Confirmation extends Controller<HTMLFormElement> {
     this.check()
   }
 
-  inputTargetDisconnect(): void {
+  inputTargetDisconnected(): void {
     this.check()
   }
 }

--- a/components/confirmation/src/index.ts
+++ b/components/confirmation/src/index.ts
@@ -19,4 +19,12 @@ export default class Confirmation extends Controller<HTMLFormElement> {
       target.disabled = disabled
     })
   }
+
+  inputTargetConnect(): void {
+    this.check()
+  }
+
+  inputTargetDisconnect(): void {
+    this.check()
+  }
 }

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -30,3 +30,7 @@ export function throttle(callback: Function, delay: number) {
 export function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms))
 }
+
+export function nextFrame() {
+  return new Promise((resolve) => requestAnimationFrame(resolve))
+}

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -30,7 +30,3 @@ export function throttle(callback: Function, delay: number) {
 export function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms))
 }
-
-export function nextFrame() {
-  return new Promise((resolve) => requestAnimationFrame(resolve))
-}


### PR DESCRIPTION
This PR improves the `Confirmation` component by ensuring that it properly handles dynamically added or removed input targets. Previously, if the form structure changed (e.g., due to Turbo or other dynamic updates), the component might not properly update its state.

**Changes**

- Implemented the existing Stimulus inputTargetConnect callback to re-run check() when new targets appear.
- Implemented the inputTargetDisconnect callback to re-run check() when targets are removed.
- Ensures the confirmation component remains accurate even when form fields are dynamically modified.

**Why?**

Without these changes, the component could fail to recognize new or removed input fields, leading to incorrect confirmation states. By leveraging Stimulus lifecycle callbacks, we ensure that `check()` is always executed when the DOM structure changes.
