### PR TITLE
Clipboard prefer target value over innerHTML

### DIFF
--- a/components/clipboard/src/index.ts
+++ b/components/clipboard/src/index.ts
@@ -27,7 +27,7 @@ export default class Clipboard extends Controller {
   copy(event: Event): void {
     event.preventDefault()
 
-    const text = this.sourceTarget.innerHTML || this.sourceTarget.value
+    const text = this.sourceTarget.value || this.sourceTarget.innerHTML
 
     navigator.clipboard.writeText(text).then(() => this.copied())
   }


### PR DESCRIPTION
Change preference to prefer target value over innerHTML.

Why? Take this example:

I have a textarea which holds HTML text which I want to copy. When innerHTML is prefered I get a string which is escaped because of js. When value is prefered, I get correct unescaped URL.

Before change:
```
&lt;iframe src="https://example.com" width="100%"&gt;&lt;/iframe&gt;
```

After change:
```
<iframe src="https://example.com" width="100%"></iframe>
```


```html
<div data-controller="clipboard" data-clipboard-success-content-value="Copied!">
  <textarea data-clipboard-target="source">
    <iframe src="https://example.com" width="100%"></iframe>
  </textarea>

  <button type="button" data-action="clipboard#copy" data-clipboard-target="button">Copy to clipboard</button>
</div>

```