### PR TITLE
[Stimulus Sortable] Add `draggable` option

### DIFF
--- a/components/sortable/src/index.ts
+++ b/components/sortable/src/index.ts
@@ -10,6 +10,7 @@ export default class StimulusSortable extends Controller<HTMLElement> {
   declare sortable: Sortable
   declare handleValue: string
   declare methodValue: string
+  declare draggableValue: string
 
   static values = {
     resourceName: String,
@@ -27,6 +28,7 @@ export default class StimulusSortable extends Controller<HTMLElement> {
       type: String,
       default: "patch",
     },
+    draggable: String,
   }
 
   initialize() {
@@ -61,10 +63,12 @@ export default class StimulusSortable extends Controller<HTMLElement> {
   }
 
   get options(): Sortable.Options {
+    const draggable = this.draggableValue || this.defaultOptions.draggable
     return {
       animation: this.animationValue || this.defaultOptions.animation || 150,
       handle: this.handleValue || this.defaultOptions.handle || undefined,
       onUpdate: this.onUpdate,
+      ...(draggable && { draggable }),
     }
   }
 


### PR DESCRIPTION
Hi

I added the `draggable` option.

This allows you to customize draggable elements. For example, `data-sortable-draggable-value=".item"`.