### PR TITLE
Add support for `form*` attributes

### DIFF
--- a/components/auto-submit/spec/index.test.ts
+++ b/components/auto-submit/spec/index.test.ts
@@ -68,4 +68,30 @@ describe("#submit", () => {
       expect(requestSubmitSpy).toHaveBeenCalledOnce()
     })
   })
+
+  describe("using a remote form", () => {
+    beforeEach(() => {
+      startStimulus()
+
+      document.body.innerHTML = `
+        <form id="my-form"></form>
+
+        <div data-controller="auto-submit">
+          <input type="checkbox" data-action="change->auto-submit#submit" form="my-form" />
+        </div>
+      `
+    })
+
+    it("should try to submit the form", async () => {
+      const requestSubmitSpy = vi.spyOn(document.querySelector("form"), "requestSubmit")
+      const checkbox: HTMLInputElement = document.querySelector("input")
+
+      checkbox.click()
+
+      // Wait for the default debounce to complete
+      await sleep(150)
+
+      expect(requestSubmitSpy).toHaveBeenCalledOnce()
+    })
+  })
 })

--- a/components/auto-submit/src/index.ts
+++ b/components/auto-submit/src/index.ts
@@ -21,7 +21,13 @@ export default class AutoSubmit extends Controller<HTMLFormElement> {
     }
   }
 
-  submit(): void {
-    this.element.requestSubmit()
+  submit(event: Event): void {
+    if (event.target instanceof HTMLInputElement && event.target.type == "submit") {
+      event.target.form.requestSubmit(event.target)
+    } else if (event.target instanceof HTMLInputElement) {
+      event.target.form.requestSubmit()
+    } else {
+      this.element.requestSubmit()
+    }
   }
 }


### PR DESCRIPTION
An form input can use some form* attributes that affect how the form is submitted. This adds support for it.

```html
<form id=“my-form” method=“post”></form>

<div data-controller=“auto-submit”>
  <input type=“text” form=“my-form” data-action="auto-submit#submit" />
</div>
```