### PR TITLE
add TextareaAutogrow example

### DIFF
--- a/components/textarea-autogrow/package.json
+++ b/components/textarea-autogrow/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "stimulus-textarea-autogrow",
+  "name": "@stimulus-components/textarea-autogrow",
   "version": "4.1.0",
   "description": "A Stimulus controller for autogrowing textarea.",
   "repository": "git@github.com:stimulus-components/stimulus-components.git",

--- a/components/textarea-autogrow/src/index.ts
+++ b/components/textarea-autogrow/src/index.ts
@@ -1,7 +1,7 @@
 import { Controller } from "@hotwired/stimulus"
 import { debounce } from "../../../utils"
 
-export default class extends Controller<HTMLInputElement> {
+export default class TextareaAutogrow extends Controller<HTMLInputElement> {
   declare onResize: EventListenerOrEventListenerObject // eslint-disable-line no-undef
   declare resizeDebounceDelayValue: number
 

--- a/docs/components/Home/ComponentsList.vue
+++ b/docs/components/Home/ComponentsList.vue
@@ -40,6 +40,7 @@ const { data: components } = await useAsyncData("components-list", () =>
           "auto-submit",
           "rails-nested-form",
           "dialog",
+          "textarea-autogrow",
         ],
       },
     })

--- a/docs/components/Home/Hero.vue
+++ b/docs/components/Home/Hero.vue
@@ -67,6 +67,7 @@ import CheckboxSelectAll from "@/components/content/Demo/CheckboxSelectAll.vue"
 import Clipboard from "@/components/content/Demo/Clipboard.vue"
 import Dropdown from "@/components/content/Demo/Dropdown.vue"
 import PasswordVisibility from "@/components/content/Demo/PasswordVisibility.vue"
+import TextareaAutogrow from "@/components/content/Demo/TextareaAutogrow.vue"
 import HeroLines from "@/components/Home/HeroLines.vue"
 
 const { data: components } = await useAsyncData("components-hero", () =>
@@ -74,7 +75,7 @@ const { data: components } = await useAsyncData("components-hero", () =>
     .sort({ title: 1 })
     .where({
       package: {
-        $in: ["character-counter", "checkbox-select-all", "clipboard", "dropdown", "password-visibility"],
+        $in: ["character-counter", "checkbox-select-all", "clipboard", "dropdown", "password-visibility", "textarea-autogrow"],
       },
     })
     .find(),
@@ -86,5 +87,6 @@ const componentsDemo = {
   clipboard: Clipboard,
   dropdown: Dropdown,
   "password-visibility": PasswordVisibility,
+  "textarea-autogrow": TextareaAutogrow,
 }
 </script>

--- a/docs/components/content/Demo/TextareaAutogrow.vue
+++ b/docs/components/content/Demo/TextareaAutogrow.vue
@@ -1,0 +1,22 @@
+<template>
+  <Block title="Textarea Autogrow" :is-home="isHome">
+    <div>
+      <textarea
+        data-controller="textarea-autogrow"
+        class="shadow-sm appearance-none border w-full py-2 px-3 rounded-l-md text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
+        placeholder="What's happening?"
+      ></textarea>
+    </div>
+  </Block>
+</template>
+
+<script setup>
+import Block from "@/components/UI/Block.vue"
+
+defineProps({
+  isHome: {
+    type: Boolean,
+    default: false,
+  },
+})
+</script>

--- a/docs/content/docs/stimulus-textarea-autogrow.md
+++ b/docs/content/docs/stimulus-textarea-autogrow.md
@@ -2,12 +2,16 @@
 title: Textarea Autogrow
 description: A Stimulus controller for autogrowing textarea.
 package: textarea-autogrow
-packagePath: "stimulus-textarea-autogrow"
+packagePath: "@stimulus-components/textarea-autogrow"
 ---
 
 ## Installation
 
 :installation-block{:package="package" :packagePath="packagePath"}
+
+## Example
+
+:textarea-autogrow
 
 ## Usage
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -42,6 +42,7 @@
     "@stimulus-components/scroll-reveal": "workspace:*",
     "@stimulus-components/sortable": "workspace:*",
     "@stimulus-components/sound": "workspace:*",
+    "@stimulus-components/textarea-autogrow": "workspace:*",
     "@stimulus-components/timeago": "workspace:*",
     "@tailwindcss/typography": "^0.5.18",
     "core-js": "^3.45.1",

--- a/docs/plugins/stimulus.client.ts
+++ b/docs/plugins/stimulus.client.ts
@@ -25,6 +25,7 @@ import ScrollProgress from "@stimulus-components/scroll-progress/src"
 import ScrollReveal from "@stimulus-components/scroll-reveal/src"
 import Sortable from "@stimulus-components/sortable/src"
 import Sound from "@stimulus-components/sound/src"
+import TextareaAutogrow from "@stimulus-components/textarea-autogrow/src"
 import Timeago from "@stimulus-components/timeago/src"
 
 // @ts-expect-error
@@ -56,6 +57,7 @@ export default defineNuxtPlugin(() => {
   application.register("scroll-reveal", ScrollReveal)
   application.register("sortable", Sortable)
   application.register("sound", Sound)
+  application.register("textarea-autogrow", TextareaAutogrow)
   application.register("timeago", Timeago)
 
   // @ts-expect-error

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -375,6 +375,9 @@ importers:
       '@stimulus-components/sound':
         specifier: workspace:*
         version: link:../components/sound
+      '@stimulus-components/textarea-autogrow':
+        specifier: workspace:*
+        version: link:../components/textarea-autogrow
       '@stimulus-components/timeago':
         specifier: workspace:*
         version: link:../components/timeago


### PR DESCRIPTION
A (possibly?) minimal change to add the demo / example to show Textarea Autogrow in action.

Not really minimal, with `stimulus-textarea-autogrow` → `@stimulus-components/textarea-autogrow`, but trying to make that consistent as well.