### PR TITLE
new controller: pluralize

### DIFF
--- a/components/pluralize/CHANGELOG.md
+++ b/components/pluralize/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.0.0] - 2025-XX-XX
+## [1.0.0] - 2025-10-01
 
 ### Added
 

--- a/components/pluralize/CHANGELOG.md
+++ b/components/pluralize/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.0] - 2025-XX-XX
+
+### Added
+
+- Adding controller

--- a/components/pluralize/README.md
+++ b/components/pluralize/README.md
@@ -1,0 +1,17 @@
+# Stimulus Pluralize
+
+## Getting started
+
+A Stimulus controller that handles choosing singular/plural strings based on a number.
+
+## 📚 Documentation
+
+See [stimulus-pluralize documentation](https://www.stimulus-components.com/docs/stimulus-pluralize/).
+
+## 👷‍♂️ Contributing
+
+Do not hesitate to contribute to the project by adapting or adding features ! Bug reports or pull requests are welcome.
+
+## 📝 License
+
+This project is released under the [MIT](http://opensource.org/licenses/MIT) license.

--- a/components/pluralize/index.html
+++ b/components/pluralize/index.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+    <title>Stimulus Pluralize</title>
+
+    <script type="module">
+      import "../app.css"
+      import { Application } from "@hotwired/stimulus"
+      import Pluralize from "./src/index"
+
+      const application = Application.start()
+      application.register("pluralize", Pluralize)
+    </script>
+  </head>
+
+  <body>
+    <div class="relative h-full max-w-5xl mx-auto px-4">
+      <section class="mt-16">
+        <div data-controller="pluralize">
+          <input
+            data-pluralize-target="input"
+            class="shadow-sm appearance-none border w-full py-2 px-3 rounded-l-md text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
+            placeholder="0"
+          ></textarea>
+
+          <p class="mt-2 text-md text-gray-800">
+            There
+            <span data-pluralize-target="text" data-singular="is" data-pluralize="are"></span>
+            <strong data-pluralize-target="value"></strong>
+            <span data-pluralize-target="text" data-singular="puppy" data-pluralize="puppies"></span>
+            from this input.
+          </p>
+        </div>
+      </section>
+    </div>
+  </body>
+</html>

--- a/components/pluralize/package.json
+++ b/components/pluralize/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@stimulus-components/pluralize",
+  "version": "5.1.0",
+  "description": "A Stimulus controller that handles choosing singular/plural strings based on a number.",
+  "keywords": [
+    "stimulus",
+    "stimulusjs",
+    "stimulus controller",
+    "input",
+    "singular",
+    "plural",
+    "pluralize"
+  ],
+  "repository": "git@github.com:stimulus-components/stimulus-components.git",
+  "bugs": {
+    "url": "https://github.com/stimulus-components/stimulus-components/issues"
+  },
+  "author": "Yossef Mendelssohn <ymendel@pobox.com>",
+  "license": "MIT",
+  "homepage": "https://github.com/stimulus-components/stimulus-components",
+  "private": false,
+  "publishConfig": {
+    "access": "public"
+  },
+  "main": "dist/stimulus-pluralize.umd.js",
+  "module": "dist/stimulus-pluralize.mjs",
+  "types": "dist/types/index.d.ts",
+  "scripts": {
+    "types": "tsc --noEmit false --declaration true --emitDeclarationOnly true --outDir dist/types",
+    "dev": "vite",
+    "build": "vite build && pnpm run types",
+    "version": "pnpm build"
+  },
+  "peerDependencies": {
+    "@hotwired/stimulus": "^3"
+  }
+}

--- a/components/pluralize/spec/index.test.ts
+++ b/components/pluralize/spec/index.test.ts
@@ -11,6 +11,10 @@ const startStimulus = (): void => {
   application.register("pluralize", Pluralize)
 }
 
+let input: HTMLInputElement
+let value: HTMLElement
+let texts: NodeListOf<HTMLElement>
+
 describe("#update", () => {
   describe("for an input", () => {
     beforeEach((): void => {
@@ -31,13 +35,13 @@ describe("#update", () => {
         from this input.
       </div>
     `
+
+      input = document.querySelector<HTMLInputElement>('[data-pluralize-target="input"]')
+      texts = document.querySelectorAll<HTMLElement>('[data-pluralize-target="text"]')
+      value = document.querySelector<HTMLElement>('[data-pluralize-target="value"]')
     })
 
     it("should correctly pluralize for 0", (): void => {
-      const input = document.querySelector<HTMLInputElement>('[data-pluralize-target="input"]')
-      const texts = document.querySelectorAll<HTMLElement>('[data-pluralize-target="text"]')
-      const value = document.querySelector<HTMLElement>('[data-pluralize-target="value"]')
-
       input.value = "0"
       input.dispatchEvent(new Event("input"))
 
@@ -47,10 +51,6 @@ describe("#update", () => {
     })
 
     it("should correctly pluralize for 1", (): void => {
-      const input = document.querySelector<HTMLInputElement>('[data-pluralize-target="input"]')
-      const texts = document.querySelectorAll<HTMLElement>('[data-pluralize-target="text"]')
-      const value = document.querySelector<HTMLElement>('[data-pluralize-target="value"]')
-
       input.value = "1"
       input.dispatchEvent(new Event("input"))
 
@@ -60,10 +60,6 @@ describe("#update", () => {
     })
 
     it("should correctly pluralize for 2", (): void => {
-      const input = document.querySelector<HTMLInputElement>('[data-pluralize-target="input"]')
-      const texts = document.querySelectorAll<HTMLElement>('[data-pluralize-target="text"]')
-      const value = document.querySelector<HTMLElement>('[data-pluralize-target="value"]')
-
       input.value = "2"
       input.dispatchEvent(new Event("input"))
 
@@ -86,12 +82,12 @@ describe("#update", () => {
         to be seen.
       </div>
     `
+
+      texts = document.querySelectorAll<HTMLElement>('[data-pluralize-target="text"]')
+      value = document.querySelector<HTMLElement>('[data-pluralize-target="observe"]')
     })
 
     it("should correctly pluralize for 0", async (): Promise<void> => {
-      const texts = document.querySelectorAll<HTMLElement>('[data-pluralize-target="text"]')
-      const value = document.querySelector<HTMLElement>('[data-pluralize-target="observe"]')
-
       value.textContent = "0"
       await new Promise(process.nextTick)
 
@@ -101,9 +97,6 @@ describe("#update", () => {
     })
 
     it("should correctly pluralize for 1", async (): Promise<void> => {
-      const texts = document.querySelectorAll<HTMLElement>('[data-pluralize-target="text"]')
-      const value = document.querySelector<HTMLElement>('[data-pluralize-target="observe"]')
-
       value.textContent = "1"
       await new Promise(process.nextTick)
 
@@ -113,9 +106,6 @@ describe("#update", () => {
     })
 
     it("should correctly pluralize for 2", async (): Promise<void> => {
-      const texts = document.querySelectorAll<HTMLElement>('[data-pluralize-target="text"]')
-      const value = document.querySelector<HTMLElement>('[data-pluralize-target="observe"]')
-
       value.textContent = "2"
       await new Promise(process.nextTick)
 

--- a/components/pluralize/spec/index.test.ts
+++ b/components/pluralize/spec/index.test.ts
@@ -1,0 +1,75 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { beforeEach, describe, it, expect } from "vitest"
+import { Application } from "@hotwired/stimulus"
+import Pluralize from "../src/index"
+
+const startStimulus = (): void => {
+  const application = Application.start()
+  application.register("pluralize", Pluralize)
+}
+
+describe("#update", () => {
+  describe("for an input", () => {
+    beforeEach((): void => {
+      startStimulus()
+
+      document.body.innerHTML = `
+      <div data-controller="pluralize">
+        <input
+          data-pluralize-target="input"
+          type="number"
+          placeholder="0"
+        >
+
+        There
+        <span data-pluralize-target="text" data-singular="is" data-plural="are"></span>
+        <strong data-pluralize-target="value"></strong>
+        <span data-pluralize-target="text" data-singular="puppy" data-plural="puppies"></span>
+        from this input.
+      </div>
+    `
+    })
+
+    it("should correctly pluralize for 0", (): void => {
+      const input = document.querySelector<HTMLInputElement>('[data-pluralize-target="input"]')
+      const texts = document.querySelectorAll<HTMLElement>('[data-pluralize-target="text"]')
+      const value = document.querySelector<HTMLElement>('[data-pluralize-target="value"]')
+
+      input.value = "0"
+      input.dispatchEvent(new Event("input"))
+
+      expect(value.innerHTML).toBe("0")
+      expect(texts[0].innerHTML).toBe("are")
+      expect(texts[1].innerHTML).toBe("puppies")
+    })
+
+    it("should correctly pluralize for 1", (): void => {
+      const input = document.querySelector<HTMLInputElement>('[data-pluralize-target="input"]')
+      const texts = document.querySelectorAll<HTMLElement>('[data-pluralize-target="text"]')
+      const value = document.querySelector<HTMLElement>('[data-pluralize-target="value"]')
+
+      input.value = "1"
+      input.dispatchEvent(new Event("input"))
+
+      expect(value.innerHTML).toBe("1")
+      expect(texts[0].innerHTML).toBe("is")
+      expect(texts[1].innerHTML).toBe("puppy")
+    })
+
+    it("should correctly pluralize for 2", (): void => {
+      const input = document.querySelector<HTMLInputElement>('[data-pluralize-target="input"]')
+      const texts = document.querySelectorAll<HTMLElement>('[data-pluralize-target="text"]')
+      const value = document.querySelector<HTMLElement>('[data-pluralize-target="value"]')
+
+      input.value = "2"
+      input.dispatchEvent(new Event("input"))
+
+      expect(value.innerHTML).toBe("2")
+      expect(texts[0].innerHTML).toBe("are")
+      expect(texts[1].innerHTML).toBe("puppies")
+    })
+  })
+})

--- a/components/pluralize/spec/index.test.ts
+++ b/components/pluralize/spec/index.test.ts
@@ -72,4 +72,56 @@ describe("#update", () => {
       expect(texts[1].innerHTML).toBe("puppies")
     })
   })
+
+  describe("for observation", () => {
+    beforeEach((): void => {
+      startStimulus()
+
+      document.body.innerHTML = `
+      <div data-controller="pluralize">
+        There
+        <span data-pluralize-target="text" data-singular="is" data-plural="are"></span>
+        <strong data-pluralize-target="observe"></strong>
+        <span data-pluralize-target="text" data-singular="puppy" data-plural="puppies"></span>
+        to be seen.
+      </div>
+    `
+    })
+
+    it("should correctly pluralize for 0", async (): Promise<void> => {
+      const texts = document.querySelectorAll<HTMLElement>('[data-pluralize-target="text"]')
+      const value = document.querySelector<HTMLElement>('[data-pluralize-target="observe"]')
+
+      value.textContent = "0"
+      await new Promise(process.nextTick)
+
+      expect(value.innerHTML).toBe("0")
+      expect(texts[0].innerHTML).toBe("are")
+      expect(texts[1].innerHTML).toBe("puppies")
+    })
+
+    it("should correctly pluralize for 1", async (): Promise<void> => {
+      const texts = document.querySelectorAll<HTMLElement>('[data-pluralize-target="text"]')
+      const value = document.querySelector<HTMLElement>('[data-pluralize-target="observe"]')
+
+      value.textContent = "1"
+      await new Promise(process.nextTick)
+
+      expect(value.innerHTML).toBe("1")
+      expect(texts[0].innerHTML).toBe("is")
+      expect(texts[1].innerHTML).toBe("puppy")
+    })
+
+    it("should correctly pluralize for 2", async (): Promise<void> => {
+      const texts = document.querySelectorAll<HTMLElement>('[data-pluralize-target="text"]')
+      const value = document.querySelector<HTMLElement>('[data-pluralize-target="observe"]')
+
+      value.textContent = "2"
+      await new Promise(process.nextTick)
+
+      expect(value.innerHTML).toBe("2")
+      expect(texts[0].innerHTML).toBe("are")
+      expect(texts[1].innerHTML).toBe("puppies")
+    })
+  })
 })

--- a/components/pluralize/src/index.ts
+++ b/components/pluralize/src/index.ts
@@ -1,0 +1,72 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class Pluralize extends Controller {
+  declare readonly inputTarget: HTMLInputElement
+  declare readonly observeTarget: HTMLElement
+  declare readonly textTargets: Array<HTMLElement>
+  declare readonly valueTargets: Array<HTMLElement>
+  declare readonly phraseTargets: Array<HTMLElement>
+
+  declare readonly hasInputTarget: boolean
+  declare readonly hasObserveTarget: boolean
+  declare readonly hasCountdownValue: boolean
+
+  static targets = ["input", "observe", "text", "value", "phrase"]
+  static values = {
+    singular: { type: String, default: "" },
+    plural: { type: String, default: "" },
+  }
+
+  initialize(): void {
+    console.log("yooooo")
+    this.update = this.update.bind(this)
+  }
+
+  connect(): void {
+    console.log("HELLO?")
+  }
+
+  inputTargetConnected(element): void {
+    console.log("input target hello?", { element })
+    this.update()
+    element.addEventListener('input', this.update)
+  }
+
+  inputTargetDisconnected(element): void {
+    console.log("input target GOODBYE", { element })
+    element.removeEventListener('input', this.update)
+  }
+
+  update(): void {
+    const number = this.number || 0
+    this.updateTargetsWithNumber(number)
+  }
+
+  get number(): number {
+    let value: string;
+
+    if (this.hasInputTarget) {
+      value = this.inputTarget.value
+    }
+
+    return Number(value)
+  }
+
+  usePlural(number): boolean {
+    return number != 1
+  }
+
+  getText(target, number): string {
+    const plural = this.usePlural(number)
+    const text = plural ? target.dataset.plural: target.dataset.singular
+
+    return text
+  }
+
+  updateTargetsWithNumber(number): void {
+    this.valueTargets.forEach((valueTarget) => valueTarget.textContent = number);
+    this.textTargets.forEach((textTarget) => {
+      textTarget.textContent = this.getText(textTarget, number)
+    });
+  }
+}

--- a/components/pluralize/src/index.ts
+++ b/components/pluralize/src/index.ts
@@ -68,9 +68,17 @@ export default class Pluralize extends Controller {
 
   getText(target, number): string {
     const plural = this.usePlural(number)
-    const text = plural ? target.dataset.plural : target.dataset.singular
+    const text = plural ? this.getPluralText(target) : this.getSingularText(target)
 
     return text
+  }
+
+  getPluralText(target): string {
+    return target.dataset.plural
+  }
+
+  getSingularText(target): string {
+    return target.dataset.singular
   }
 
   updateTargetsWithNumber(number): void {

--- a/components/pluralize/src/index.ts
+++ b/components/pluralize/src/index.ts
@@ -2,39 +2,24 @@ import { Controller } from "@hotwired/stimulus"
 
 export default class Pluralize extends Controller {
   declare readonly inputTarget: HTMLInputElement
-  declare readonly observeTarget: HTMLElement
   declare readonly textTargets: Array<HTMLElement>
   declare readonly valueTargets: Array<HTMLElement>
-  declare readonly phraseTargets: Array<HTMLElement>
 
   declare readonly hasInputTarget: boolean
-  declare readonly hasObserveTarget: boolean
-  declare readonly hasCountdownValue: boolean
 
-  static targets = ["input", "observe", "text", "value", "phrase"]
-  static values = {
-    singular: { type: String, default: "" },
-    plural: { type: String, default: "" },
-  }
+  static targets = ["input", "text", "value"]
 
   initialize(): void {
-    console.log("yooooo")
     this.update = this.update.bind(this)
   }
 
-  connect(): void {
-    console.log("HELLO?")
-  }
-
   inputTargetConnected(element): void {
-    console.log("input target hello?", { element })
     this.update()
-    element.addEventListener('input', this.update)
+    element.addEventListener("input", this.update)
   }
 
   inputTargetDisconnected(element): void {
-    console.log("input target GOODBYE", { element })
-    element.removeEventListener('input', this.update)
+    element.removeEventListener("input", this.update)
   }
 
   update(): void {
@@ -43,7 +28,7 @@ export default class Pluralize extends Controller {
   }
 
   get number(): number {
-    let value: string;
+    let value: string
 
     if (this.hasInputTarget) {
       value = this.inputTarget.value
@@ -58,15 +43,15 @@ export default class Pluralize extends Controller {
 
   getText(target, number): string {
     const plural = this.usePlural(number)
-    const text = plural ? target.dataset.plural: target.dataset.singular
+    const text = plural ? target.dataset.plural : target.dataset.singular
 
     return text
   }
 
   updateTargetsWithNumber(number): void {
-    this.valueTargets.forEach((valueTarget) => valueTarget.textContent = number);
+    this.valueTargets.forEach((valueTarget) => valueTarget.textContent = number)
     this.textTargets.forEach((textTarget) => {
       textTarget.textContent = this.getText(textTarget, number)
-    });
+    })
   }
 }

--- a/components/pluralize/src/index.ts
+++ b/components/pluralize/src/index.ts
@@ -46,11 +46,11 @@ export default class Pluralize extends Controller {
   }
 
   update(): void {
-    const number = this.number || 0
-    this.updateTargetsWithNumber(number)
+    const count = this.count || 0
+    this.updateTargetsWithCount(count)
   }
 
-  get number(): number {
+  get count(): number {
     let value: string
 
     if (this.hasInputTarget) {
@@ -62,12 +62,12 @@ export default class Pluralize extends Controller {
     return Number(value)
   }
 
-  usePlural(number): boolean {
-    return number != 1
+  usePlural(count): boolean {
+    return count != 1
   }
 
-  getText(target, number): string {
-    const plural = this.usePlural(number)
+  getText(target, count): string {
+    const plural = this.usePlural(count)
     const text = plural ? this.getPluralText(target) : this.getSingularText(target)
 
     return text
@@ -81,10 +81,10 @@ export default class Pluralize extends Controller {
     return target.dataset.singular
   }
 
-  updateTargetsWithNumber(number): void {
-    this.valueTargets.forEach((valueTarget) => valueTarget.textContent = number)
+  updateTargetsWithCount(count): void {
+    this.valueTargets.forEach((valueTarget) => valueTarget.textContent = count)
     this.textTargets.forEach((textTarget) => {
-      textTarget.textContent = this.getText(textTarget, number)
+      textTarget.textContent = this.getText(textTarget, count)
     })
   }
 }

--- a/components/pluralize/tsconfig.json
+++ b/components/pluralize/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.json"
+}

--- a/components/pluralize/vite.config.mts
+++ b/components/pluralize/vite.config.mts
@@ -1,0 +1,23 @@
+import { resolve } from "path"
+import { defineConfig } from "vite"
+
+export default defineConfig({
+  esbuild: {
+    minifyIdentifiers: false,
+  },
+  build: {
+    lib: {
+      entry: resolve(__dirname, "src/index.ts"),
+      name: "StimulusPluralize",
+      fileName: "stimulus-pluralize",
+    },
+    rollupOptions: {
+      external: ["@hotwired/stimulus"],
+      output: {
+        globals: {
+          "@hotwired/stimulus": "Stimulus",
+        },
+      },
+    },
+  },
+})

--- a/docs/components/Home/ComponentsList.vue
+++ b/docs/components/Home/ComponentsList.vue
@@ -40,6 +40,7 @@ const { data: components } = await useAsyncData("components-list", () =>
           "auto-submit",
           "rails-nested-form",
           "dialog",
+          "pluralize",
         ],
       },
     })

--- a/docs/components/Home/Hero.vue
+++ b/docs/components/Home/Hero.vue
@@ -67,6 +67,7 @@ import CheckboxSelectAll from "@/components/content/Demo/CheckboxSelectAll.vue"
 import Clipboard from "@/components/content/Demo/Clipboard.vue"
 import Dropdown from "@/components/content/Demo/Dropdown.vue"
 import PasswordVisibility from "@/components/content/Demo/PasswordVisibility.vue"
+import Pluralize from "@/components/content/Demo/Pluralize.vue"
 import HeroLines from "@/components/Home/HeroLines.vue"
 
 const { data: components } = await useAsyncData("components-hero", () =>
@@ -74,7 +75,7 @@ const { data: components } = await useAsyncData("components-hero", () =>
     .sort({ title: 1 })
     .where({
       package: {
-        $in: ["character-counter", "checkbox-select-all", "clipboard", "dropdown", "password-visibility"],
+        $in: ["character-counter", "checkbox-select-all", "clipboard", "dropdown", "password-visibility", "pluralize"],
       },
     })
     .find(),
@@ -86,5 +87,6 @@ const componentsDemo = {
   clipboard: Clipboard,
   dropdown: Dropdown,
   "password-visibility": PasswordVisibility,
+  pluralize: Pluralize,
 }
 </script>

--- a/docs/components/content/Demo/Pluralize.vue
+++ b/docs/components/content/Demo/Pluralize.vue
@@ -1,0 +1,23 @@
+<template>
+  <Block title="Pluralize">
+    <div data-controller="pluralize">
+      <input
+        data-pluralize-target="input"
+        class="shadow-sm appearance-none border w-full py-2 px-3 rounded-l-md text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
+        placeholder="0"
+      >
+
+      <p class="mt-2 text-md text-gray-800">
+        There
+        <span data-pluralize-target="text" data-singular="is" data-plural="are"></span>
+        <strong data-pluralize-target="value"></strong>
+        <span data-pluralize-target="text" data-singular="puppy" data-plural="puppies"></span>
+        from this input.
+      </p>
+    </div>
+  </Block>
+</template>
+
+<script setup>
+import Block from "@/components/UI/Block.vue"
+</script>

--- a/docs/components/content/Demo/Pluralize.vue
+++ b/docs/components/content/Demo/Pluralize.vue
@@ -1,5 +1,6 @@
 <template>
   <Block title="Pluralize">
+    <h2 class="text-xl mt-8 mb-2">Using input</h2>
     <div data-controller="pluralize">
       <input
         data-pluralize-target="input"
@@ -8,11 +9,20 @@
       >
 
       <p class="mt-2 text-md text-gray-800">
-        There
-        <span data-pluralize-target="text" data-singular="is" data-plural="are"></span>
-        <strong data-pluralize-target="value"></strong>
-        <span data-pluralize-target="text" data-singular="puppy" data-plural="puppies"></span>
-        from this input.
+        There <span data-pluralize-target="text" data-singular="is" data-plural="are"></span> <strong data-pluralize-target="value"></strong> <span data-pluralize-target="text" data-singular="puppy" data-plural="puppies"></span> from this input.
+      </p>
+    </div>
+
+    <h2 class="text-xl mt-8 mb-2">Observing changes</h2>
+    <div data-controller="character-counter pluralize">
+      <textarea
+        data-character-counter-target="input"
+        class="shadow-sm appearance-none border w-full py-2 px-3 rounded-l-md text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
+        placeholder="What's happening?"
+      ></textarea>
+
+      <p class="mt-2 text-md text-gray-800 dark:text-gray-300">
+        There <span data-pluralize-target="text" data-singular="is" data-plural="are"></span> <strong data-character-counter-target="counter" data-pluralize-target="observe"></strong> <span data-pluralize-target="text" data-singular="character" data-plural="characters"></span> in this textarea.
       </p>
     </div>
   </Block>

--- a/docs/content/docs/stimulus-pluralize.md
+++ b/docs/content/docs/stimulus-pluralize.md
@@ -64,7 +64,7 @@ export default class extends Pluralize {
 
   // Function to override if you want to change the logic from
   // 1 = singular, otherwise plural
-  getText(target, number)
+  getText(target, count)
 }
 ```
 

--- a/docs/content/docs/stimulus-pluralize.md
+++ b/docs/content/docs/stimulus-pluralize.md
@@ -18,6 +18,7 @@ packagePath: "@stimulus-components/pluralize"
 ::code-block{tabName="app/views/index.html"}
 
 ```html
+<!-- using input -->
 <div data-controller="pluralize">
   <input data-pluralize-target="input" type="number" placeholder="0">
 
@@ -27,7 +28,45 @@ packagePath: "@stimulus-components/pluralize"
   <span data-pluralize-target="text" data-singular="puppy" data-plural="puppies"></span>
   from this input.
 </div>
+
+<!-- using observation -->
+<div data-controller="pluralize">
+  <input data-pluralize-target="input" type="number" placeholder="0">
+
+  There
+  <span data-pluralize-target="text" data-singular="is" data-plural="are"></span>
+  <strong data-pluralize-target="observe"></strong>
+  <span data-pluralize-target="text" data-singular="puppy" data-plural="puppies"></span>
+  from this observation.
+</div>
+
 ```
 
-<!-- :: -->
+## Extending Controller
+
+::extending-controller
+::code-block{tabName="app/javascript/controllers/pluralize_controller.js"}
+
+```js
+import Pluralize from "@stimulus-components/pluralize"
+
+export default class extends Pluralize {
+  connect() {
+    super.connect()
+    console.log("Do what you want here.")
+  }
+
+  // Function to override when getting plural text for a target
+  getPlural(target)
+
+  // Function to override when getting singular text for a target
+  getSingular(target)
+
+  // Function to override if you want to change the logic from
+  // 1 = singular, otherwise plural
+  getText(target, number)
+}
+```
+
+::
 ::

--- a/docs/content/docs/stimulus-pluralize.md
+++ b/docs/content/docs/stimulus-pluralize.md
@@ -1,0 +1,33 @@
+---
+title: Pluralize
+description: A Stimulus controller that handles choosing singular/plural strings based on a number.
+package: pluralize
+packagePath: "@stimulus-components/pluralize"
+---
+
+## Installation
+
+:installation-block{:package="package" :packagePath="packagePath"}
+
+## Example
+
+:pluralize
+
+## Usage
+
+::code-block{tabName="app/views/index.html"}
+
+```html
+<div data-controller="pluralize">
+  <input data-pluralize-target="input" type="number" placeholder="0">
+
+  There
+  <span data-pluralize-target="text" data-singular="is" data-plural="are"></span>
+  <strong data-pluralize-target="value"></strong>
+  <span data-pluralize-target="text" data-singular="puppy" data-plural="puppies"></span>
+  from this input.
+</div>
+```
+
+<!-- :: -->
+::

--- a/docs/package.json
+++ b/docs/package.json
@@ -33,6 +33,7 @@
     "@stimulus-components/lightbox": "workspace:*",
     "@stimulus-components/notification": "workspace:*",
     "@stimulus-components/password-visibility": "workspace:*",
+    "@stimulus-components/pluralize": "workspace:*",
     "@stimulus-components/popover": "workspace:*",
     "@stimulus-components/rails-nested-form": "workspace:*",
     "@stimulus-components/read-more": "workspace:*",

--- a/docs/plugins/stimulus.client.ts
+++ b/docs/plugins/stimulus.client.ts
@@ -16,6 +16,7 @@ import Glow from "stimulus-glow/src"
 import Lightbox from "@stimulus-components/lightbox/src"
 import Notification from "@stimulus-components/notification/src"
 import PasswordVisibility from "@stimulus-components/password-visibility/src"
+import Pluralize from "@stimulus-components/pluralize/src"
 import Popover from "@stimulus-components/popover/src"
 import RailsNestedForm from "@stimulus-components/rails-nested-form/src"
 import ReadMore from "@stimulus-components/read-more/src"
@@ -48,6 +49,7 @@ export default defineNuxtPlugin(() => {
   application.register("nested-form", RailsNestedForm)
   application.register("notification", Notification)
   application.register("password-visibility", PasswordVisibility)
+  application.register("pluralize", Pluralize)
   application.register("popover", Popover)
   application.register("read-more", ReadMore)
   application.register("remote", RemoteRails)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -183,6 +183,12 @@ importers:
         specifier: ^3
         version: 3.2.2
 
+  components/pluralize:
+    dependencies:
+      '@hotwired/stimulus':
+        specifier: ^3
+        version: 3.2.2
+
   components/popover:
     dependencies:
       '@hotwired/stimulus':
@@ -348,6 +354,9 @@ importers:
       '@stimulus-components/password-visibility':
         specifier: workspace:*
         version: link:../components/password-visibility
+      '@stimulus-components/pluralize':
+        specifier: workspace:*
+        version: link:../components/pluralize
       '@stimulus-components/popover':
         specifier: workspace:*
         version: link:../components/popover


### PR DESCRIPTION
This is a simple controller that's been pulled out from some internal projects.

A wonderful colleague recently pointed me at the Stimulus Components page, and we were surprised to see there wasn't a pluralization controller. The character-counter one also got me to add in the "observe" functionality as well as the "input".

Here's the example in action:

![Large GIF (912x470)](https://github.com/user-attachments/assets/587a6a6d-8fc9-4f75-aa5c-c5eebc7684a5)

Hope people find this helpful!