### PR TITLE
fix(docs): support dark mode in demos

### DIFF
--- a/docs/components/content/Demo/CharacterCounter.vue
+++ b/docs/components/content/Demo/CharacterCounter.vue
@@ -3,7 +3,7 @@
     <div data-controller="character-counter">
       <textarea
         data-character-counter-target="input"
-        class="shadow-sm appearance-none border w-full py-2 px-3 rounded-l-md text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
+        class="shadow-sm appearance-none border w-full py-2 px-3 rounded-l-md text-gray-700 dark:text-gray-300 leading-tight focus:outline-none focus:shadow-outline bg-white dark:bg-slate-800 border-slate-200 dark:border-slate-600"
         placeholder="What's happening?"
       ></textarea>
 

--- a/docs/components/content/Demo/Clipboard.vue
+++ b/docs/components/content/Demo/Clipboard.vue
@@ -10,13 +10,13 @@
         value="Click the button to copy me!"
         data-clipboard-target="source"
         readonly
-        class="w-full bg-gray-100 py-3 px-2 outline-none flex-1 block rounded-none rounded-l-md sm:text-sm border border-gray-300"
+        class="w-full bg-gray-100 py-3 px-2 outline-none flex-1 block rounded-none rounded-l-md sm:text-sm border border-gray-300 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200"
       />
       <button
         type="button"
         data-action="clipboard#copy"
         data-clipboard-target="button"
-        class="inline-flex items-center gap-1 px-3 focus:outline-none rounded-r-md border border-l-0 border-gray-300 bg-gray-50 text-gray-500 text-sm"
+        class="inline-flex items-center gap-1 px-3 focus:outline-none rounded-r-md border border-l-0 border-gray-300 bg-gray-50 text-gray-500 text-sm dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200"
       >
         <ClipboardDocumentCheckIcon class="size-5" />
 

--- a/docs/components/content/Demo/Confirmation.vue
+++ b/docs/components/content/Demo/Confirmation.vue
@@ -2,14 +2,16 @@
   <Block title="Confirmation">
     <form data-controller="confirmation" class="space-y-3">
       <div>
-        <label for="confirmation" class="block text-sm/6 font-medium text-gray-900">Type "DELETE" to confirm</label>
+        <label for="confirmation" class="block text-sm/6 font-medium text-gray-900 dark:text-gray-200"
+          >Type "DELETE" to confirm</label
+        >
         <div class="mt-2">
           <input
             id="confirmation"
             data-confirmation-target="input"
             data-confirmation-content="DELETE"
             data-action="confirmation#check"
-            class="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-orange-600 sm:text-sm/6"
+            class="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-orange-600 sm:text-sm/6 dark:bg-slate-800 dark:text-slate-200 dark:outline-slate-600 dark:placeholder:text-slate-400"
             placeholder="Are you sure?"
           />
         </div>

--- a/docs/components/content/Demo/ConfirmationCheckboxes.vue
+++ b/docs/components/content/Demo/ConfirmationCheckboxes.vue
@@ -2,7 +2,7 @@
   <Block title="Confirmation">
     <form data-controller="confirmation" class="space-y-3">
       <div>
-        <label for="confirmation-checkbox" class="block text-sm/6 font-medium text-gray-900"
+        <label for="confirmation-checkbox" class="block text-sm/6 font-medium text-gray-900 dark:text-gray-200"
           >Type "DELETE" to confirm</label
         >
         <div class="mt-2">
@@ -11,14 +11,14 @@
             data-confirmation-target="input"
             data-confirmation-content="DELETE"
             data-action="confirmation#check"
-            class="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-orange-600 sm:text-sm/6"
+            class="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-orange-600 sm:text-sm/6 dark:bg-slate-800 dark:text-slate-200 dark:outline-slate-600 dark:placeholder:text-slate-400"
             placeholder="Are you sure?"
           />
         </div>
       </div>
 
       <div>
-        <label>
+        <label class="dark:text-gray-300">
           <input data-confirmation-target="input" data-action="confirmation#check" type="checkbox" />
 
           I have read the terms and conditions
@@ -26,7 +26,7 @@
       </div>
 
       <div>
-        <label>
+        <label class="dark:text-gray-300">
           <input data-confirmation-target="input" data-action="confirmation#check" type="checkbox" />
 
           I confirm that I want to permanently delete this project
@@ -43,12 +43,14 @@
       </button>
 
       <div>
-        <label for="explanation" class="block text-sm/6 font-medium text-gray-900">Explanation</label>
+        <label for="explanation" class="block text-sm/6 font-medium text-gray-900 dark:text-gray-200"
+          >Explanation</label
+        >
 
         <input
           id="explanation"
           data-confirmation-target="item"
-          class="disabled:cursor-not-allowed block w-full rounded-md disabled:bg-gray-100 bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-orange-600 sm:text-sm/6"
+          class="disabled:cursor-not-allowed block w-full rounded-md disabled:bg-gray-100 bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-orange-600 sm:text-sm/6 dark:bg-slate-800 dark:text-slate-200 dark:outline-slate-600 dark:placeholder:text-slate-400 dark:disabled:bg-slate-700"
           disabled
           placeholder="Explain here why you want to permanently delete this project"
         />

--- a/docs/components/content/Demo/PasswordVisibility.vue
+++ b/docs/components/content/Demo/PasswordVisibility.vue
@@ -1,13 +1,13 @@
 <template>
   <Block title="Password Visibility">
     <div data-controller="password-visibility">
-      <label for="password" class="block text-sm font-medium text-gray-700">Password</label>
+      <label for="password" class="block text-sm font-medium text-gray-700 dark:text-gray-200">Password</label>
       <div class="mt-1 relative rounded-md shadow-sm">
         <input
           id="password"
           type="password"
           name="password"
-          class="focus:ring-indigo-500 focus:border-indigo-500 block w-full p-2 pr-10 sm:text-sm border border-gray-300 rounded-md"
+          class="focus:ring-indigo-500 focus:border-indigo-500 block w-full p-2 pr-10 sm:text-sm border border-gray-300 rounded-md dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200 dark:placeholder:text-slate-400"
           placeholder="Your password"
           value="my-super-secret-password"
           data-password-visibility-target="input"
@@ -16,7 +16,7 @@
         <button
           data-action="password-visibility#toggle"
           type="button"
-          class="text-gray-500 absolute inset-y-0 right-0 pr-3 flex items-center cursor-pointer"
+          class="text-gray-500 dark:text-slate-400 absolute inset-y-0 right-0 pr-3 flex items-center cursor-pointer"
         >
           <!-- Heroicon name: outline/eye -->
           <svg

--- a/docs/components/content/Demo/RailsNestedForm.vue
+++ b/docs/components/content/Demo/RailsNestedForm.vue
@@ -3,17 +3,19 @@
     <form data-controller="nested-form">
       <div v-pre class="hidden" type="text/x-template" data-nested-form-target="template">
         <div class="mt-4 nested-form-wrapper" data-new-record="true">
-          <label for="NEW_RECORD" class="block text-sm font-medium leading-5 text-gray-700">New todo</label>
+          <label for="NEW_RECORD" class="block text-sm font-medium leading-5 text-gray-700 dark:text-gray-200"
+            >New todo</label
+          >
           <div class="mt-1 flex relative rounded-md shadow-sm">
             <input
               id="NEW_RECORD"
               name="user[todos_attributes][NEW_RECORD][description]"
-              class="appearance-none border w-full py-2 px-3 rounded-l-md text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
+              class="appearance-none border w-full py-2 px-3 rounded-l-md text-gray-700 leading-tight focus:outline-none focus:shadow-outline dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200 dark:placeholder:text-slate-400"
               placeholder="Your todo"
             />
 
             <button
-              class="cursor-pointer inline-flex items-center px-3 rounded-r-md border border-l-0 border-gray-300 bg-gray-100 text-gray-500 sm:text-sm"
+              class="cursor-pointer inline-flex items-center px-3 rounded-r-md border border-l-0 border-gray-300 bg-gray-100 text-gray-500 sm:text-sm dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200"
               type="button"
               data-action="nested-form#remove"
               title="Remove todo"
@@ -27,17 +29,19 @@
       </div>
 
       <div class="mt-4 nested-form-wrapper" data-new-record="false">
-        <label for="todo-1" class="block text-sm font-medium leading-5 text-gray-700">Your todo</label>
+        <label for="todo-1" class="block text-sm font-medium leading-5 text-gray-700 dark:text-gray-200"
+          >Your todo</label
+        >
         <div class="mt-1 flex relative rounded-md shadow-sm">
           <input
             id="todo-1"
             name="user[todos_attributes][0][description]"
-            class="appearance-none border w-full py-2 px-3 rounded-l-md text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
+            class="appearance-none border w-full py-2 px-3 rounded-l-md text-gray-700 leading-tight focus:outline-none focus:shadow-outline dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200"
             value="Pet the cat"
           />
 
           <button
-            class="cursor-pointer inline-flex items-center px-3 rounded-r-md border border-l-0 border-gray-300 bg-gray-100 text-gray-500 sm:text-sm"
+            class="cursor-pointer inline-flex items-center px-3 rounded-r-md border border-l-0 border-gray-300 bg-gray-100 text-gray-500 sm:text-sm dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200"
             type="button"
             data-action="nested-form#remove"
             title="Remove todo"
@@ -56,7 +60,7 @@
           id="nested-form-button"
           type="button"
           data-action="nested-form#add"
-          class="bg-white hover:bg-gray-100 text-gray-800 font-semibold py-2 px-4 border rounded shadow"
+          class="bg-white hover:bg-gray-100 text-gray-800 font-semibold py-2 px-4 border rounded shadow dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700"
         >
           Add todo
         </button>

--- a/docs/components/content/Demo/Sound.vue
+++ b/docs/components/content/Demo/Sound.vue
@@ -1,15 +1,27 @@
 <template>
   <Block title="Sound">
     <div data-controller="sound" data-sound-url-value="/sound.mp3" class="flex flex-col md:flex-row flex-wrap gap-3">
-      <button type="button" data-action="sound#play" class="px-2 py-1 border rounded-md hover:bg-gray-100">
+      <button
+        type="button"
+        data-action="sound#play"
+        class="px-2 py-1 border rounded-md hover:bg-gray-100 dark:border-slate-600 dark:text-slate-200 dark:hover:bg-slate-700"
+      >
         ▶️ Play
       </button>
 
-      <button type="button" data-action="sound#pause" class="px-2 py-1 border rounded-md hover:bg-gray-100">
+      <button
+        type="button"
+        data-action="sound#pause"
+        class="px-2 py-1 border rounded-md hover:bg-gray-100 dark:border-slate-600 dark:text-slate-200 dark:hover:bg-slate-700"
+      >
         ⏸️ Pause
       </button>
 
-      <button type="button" data-action="sound#reset" class="px-2 py-1 border rounded-md hover:bg-gray-100">
+      <button
+        type="button"
+        data-action="sound#reset"
+        class="px-2 py-1 border rounded-md hover:bg-gray-100 dark:border-slate-600 dark:text-slate-200 dark:hover:bg-slate-700"
+      >
         ⏹️ Reset
       </button>
 
@@ -17,7 +29,7 @@
         type="button"
         data-action="sound#muted"
         data-sound-muted-param="true"
-        class="px-2 py-1 border rounded-md hover:bg-gray-100"
+        class="px-2 py-1 border rounded-md hover:bg-gray-100 dark:border-slate-600 dark:text-slate-200 dark:hover:bg-slate-700"
       >
         🔇 Mute
       </button>
@@ -26,7 +38,7 @@
         type="button"
         data-action="sound#muted"
         data-sound-muted-param="false"
-        class="px-2 py-1 border rounded-md hover:bg-gray-100"
+        class="px-2 py-1 border rounded-md hover:bg-gray-100 dark:border-slate-600 dark:text-slate-200 dark:hover:bg-slate-700"
       >
         🔈 Unmute
       </button>
@@ -35,7 +47,7 @@
         type="button"
         data-action="sound#loop"
         data-sound-loop-param="true"
-        class="px-2 py-1 border rounded-md hover:bg-gray-100"
+        class="px-2 py-1 border rounded-md hover:bg-gray-100 dark:border-slate-600 dark:text-slate-200 dark:hover:bg-slate-700"
       >
         🔁 Loop
       </button>
@@ -44,7 +56,7 @@
         type="button"
         data-action="sound#volume"
         data-sound-volume-param="1"
-        class="px-2 py-1 border rounded-md hover:bg-gray-100"
+        class="px-2 py-1 border rounded-md hover:bg-gray-100 dark:border-slate-600 dark:text-slate-200 dark:hover:bg-slate-700"
       >
         🔊 100%
       </button>
@@ -53,7 +65,7 @@
         type="button"
         data-action="sound#volume"
         data-sound-volume-param="0.25"
-        class="px-2 py-1 border rounded-md hover:bg-gray-100"
+        class="px-2 py-1 border rounded-md hover:bg-gray-100 dark:border-slate-600 dark:text-slate-200 dark:hover:bg-slate-700"
       >
         🔉 25%
       </button>


### PR DESCRIPTION
## Summary

Add dark mode styles to the Character Counter, Clipboard, Confirmation, Password Visibility, Rails Nested Form, and Sound demos.

## Screenshots

### Character Counter

| Before | After |
| --- | --- |
| ![Before](https://raw.githubusercontent.com/hulk-higakijin/stimulus-components/screenshots/pr-230/pr-screenshots/230/character-counter-before.png) | ![After](https://raw.githubusercontent.com/hulk-higakijin/stimulus-components/screenshots/pr-230/pr-screenshots/230/character-counter-after.png) |

### Clipboard

| Before | After |
| --- | --- |
| ![Before](https://raw.githubusercontent.com/hulk-higakijin/stimulus-components/screenshots/pr-230/pr-screenshots/230/clipboard-before.png) | ![After](https://raw.githubusercontent.com/hulk-higakijin/stimulus-components/screenshots/pr-230/pr-screenshots/230/clipboard-after.png) |

### Confirmation

| Before | After |
| --- | --- |
| ![Before](https://raw.githubusercontent.com/hulk-higakijin/stimulus-components/screenshots/pr-230/pr-screenshots/230/confirmation-before.png) | ![After](https://raw.githubusercontent.com/hulk-higakijin/stimulus-components/screenshots/pr-230/pr-screenshots/230/confirmation-after.png) |

### Password Visibility

| Before | After |
| --- | --- |
| ![Before](https://raw.githubusercontent.com/hulk-higakijin/stimulus-components/screenshots/pr-230/pr-screenshots/230/password-visibility-before.png) | ![After](https://raw.githubusercontent.com/hulk-higakijin/stimulus-components/screenshots/pr-230/pr-screenshots/230/password-visibility-after.png) |

### Rails Nested Form

| Before | After |
| --- | --- |
| ![Before](https://raw.githubusercontent.com/hulk-higakijin/stimulus-components/screenshots/pr-230/pr-screenshots/230/rails-nested-form-before.png) | ![After](https://raw.githubusercontent.com/hulk-higakijin/stimulus-components/screenshots/pr-230/pr-screenshots/230/rails-nested-form-after.png) |

### Sound

| Before | After |
| --- | --- |
| ![Before](https://raw.githubusercontent.com/hulk-higakijin/stimulus-components/screenshots/pr-230/pr-screenshots/230/sound-before.png) | ![After](https://raw.githubusercontent.com/hulk-higakijin/stimulus-components/screenshots/pr-230/pr-screenshots/230/sound-after.png) |

## Testing

- `pnpm exec prettier --check` for the changed Vue files
- Verified the affected demos in dark mode
