### PR TITLE
feat(sortable): add draggable option

### DIFF
--- a/components/sortable/spec/index.test.ts
+++ b/components/sortable/spec/index.test.ts
@@ -1,0 +1,146 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { beforeEach, afterEach, describe, it, expect } from "vitest"
+import { Application } from "@hotwired/stimulus"
+import StimulusSortable from "../src/index"
+
+let application: Application
+
+const startStimulus = (): void => {
+  application = Application.start()
+  application.register("sortable", StimulusSortable)
+}
+
+const getController = (): StimulusSortable => {
+  const element = document.querySelector<HTMLElement>('[data-controller="sortable"]')
+  return application.getControllerForElementAndIdentifier(element, "sortable") as StimulusSortable
+}
+
+afterEach((): void => {
+  application.stop()
+})
+
+describe("StimulusSortable", () => {
+  describe("default options", () => {
+    beforeEach((): void => {
+      startStimulus()
+
+      document.body.innerHTML = `
+      <ul data-controller="sortable">
+        <li>Item 1</li>
+        <li>Item 2</li>
+        <li>Item 3</li>
+      </ul>
+    `
+    })
+
+    it("creates a sortable instance", (): void => {
+      const controller = getController()
+
+      expect(controller.sortable).toBeDefined()
+    })
+
+    it("uses default animation value", (): void => {
+      const controller = getController()
+
+      expect(controller.options.animation).toBe(150)
+    })
+
+    it("has no handle by default", (): void => {
+      const controller = getController()
+
+      expect(controller.options.handle).toBeUndefined()
+    })
+
+    it("has no draggable selector by default", (): void => {
+      const controller = getController()
+
+      expect(controller.options.draggable).toBeUndefined()
+    })
+
+    it("sortable instance uses >li as default draggable for ul elements", (): void => {
+      const controller = getController()
+
+      expect(controller.sortable.options.draggable).toBe(">li")
+    })
+  })
+
+  describe("default draggable on a div container", () => {
+    beforeEach((): void => {
+      startStimulus()
+
+      document.body.innerHTML = `
+      <div data-controller="sortable">
+        <div>Item 1</div>
+        <div>Item 2</div>
+      </div>
+    `
+    })
+
+    it("sortable instance uses >* as default draggable for non-list elements", (): void => {
+      const controller = getController()
+
+      expect(controller.sortable.options.draggable).toBe(">*")
+    })
+  })
+
+  describe("with draggable value", () => {
+    beforeEach((): void => {
+      startStimulus()
+
+      document.body.innerHTML = `
+      <ul data-controller="sortable" data-sortable-draggable-value=".item">
+        <li class="item">Draggable 1</li>
+        <li class="item">Draggable 2</li>
+        <li class="fixed">Not draggable</li>
+      </ul>
+    `
+    })
+
+    it("passes draggable selector to sortable options", (): void => {
+      const controller = getController()
+
+      expect(controller.options.draggable).toBe(".item")
+    })
+  })
+
+  describe("with handle value", () => {
+    beforeEach((): void => {
+      startStimulus()
+
+      document.body.innerHTML = `
+      <ul data-controller="sortable" data-sortable-handle-value=".handle">
+        <li><span class="handle">drag</span> Item 1</li>
+        <li><span class="handle">drag</span> Item 2</li>
+      </ul>
+    `
+    })
+
+    it("passes handle selector to sortable options", (): void => {
+      const controller = getController()
+
+      expect(controller.options.handle).toBe(".handle")
+    })
+  })
+
+  describe("with custom animation", () => {
+    beforeEach((): void => {
+      startStimulus()
+
+      document.body.innerHTML = `
+      <ul data-controller="sortable" data-sortable-animation-value="300">
+        <li>Item 1</li>
+        <li>Item 2</li>
+      </ul>
+    `
+    })
+
+    it("uses the provided animation value", (): void => {
+      const controller = getController()
+
+      expect(controller.options.animation).toBe(300)
+    })
+  })
+})

--- a/components/sortable/src/index.ts
+++ b/components/sortable/src/index.ts
@@ -10,6 +10,7 @@ export default class StimulusSortable extends Controller<HTMLElement> {
   declare sortable: Sortable
   declare handleValue: string
   declare methodValue: string
+  declare draggableValue: string
 
   static values = {
     resourceName: String,
@@ -27,6 +28,7 @@ export default class StimulusSortable extends Controller<HTMLElement> {
       type: String,
       default: "patch",
     },
+    draggable: String,
   }
 
   initialize() {
@@ -60,10 +62,13 @@ export default class StimulusSortable extends Controller<HTMLElement> {
   }
 
   get options(): Sortable.Options {
+    const draggable = this.draggableValue || this.defaultOptions.draggable
+
     return {
       animation: this.animationValue || this.defaultOptions.animation || 150,
       handle: this.handleValue || this.defaultOptions.handle || undefined,
       onUpdate: this.onUpdate,
+      ...(draggable && { draggable }),
     }
   }
 

--- a/docs/content/docs/stimulus-sortable.md
+++ b/docs/content/docs/stimulus-sortable.md
@@ -82,6 +82,20 @@ In your views:
 
 ::
 
+### With draggable selector
+
+::code-block{tabName="app/views/index.html"}
+
+```html
+<ul data-controller="sortable" data-sortable-draggable-value=".item">
+  <li class="item">Pet the cat</li>
+  <li class="item">Get the groceries</li>
+  <li class="not-sortable">This item cannot be sorted</li>
+</ul>
+```
+
+::
+
 ### With AJAX call
 
 If you're using [@rails/request.js](https://github.com/rails/request.js) in your application, you can add an url as data-attribute on every items to perform an AJAX call to update the new position automatically on drop.
@@ -113,6 +127,7 @@ If you use `data-sortable-resource-name-value`, the name will be used. For insta
 | `data-sortable-method-value`        | `patch`     | The HTTP method you want for `@rails/request.js`.                          | ✅       |
 | `data-sortable-animation-value`     | `150`       | Animation speed moving items when sorting in milliseconds. `0` to disable. | ✅       |
 | `data-sortable-handle-value`        | `undefined` | Drag handle selector within list items.                                    | ✅       |
+| `data-sortable-draggable-value`     | `>li` or `>*` | CSS selector of draggable items within the container. Defaults to `>li` for `<ul>`/`<ol>`, `>*` otherwise. | ✅       |
 
 ## Extending Controller
 


### PR DESCRIPTION
## Summary

- Add `data-sortable-draggable-value` option to the sortable controller, allowing users to specify a CSS selector to restrict which items are draggable
- When no value is provided, SortableJS uses its default (`>li` for `<ul>`/`<ol>`, `>*` otherwise)
- Add tests for the sortable controller (default options, draggable, handle, animation)
- Update documentation with usage example and configuration table

## Test plan

- [x] `pnpm exec vitest --run components/sortable/spec/index.test.ts` — 9 tests pass
- [x] `pnpm -C components/sortable run build` — build + types OK
- [x] `pnpm run lint` — no errors